### PR TITLE
Add meson.build for auto generating makefile

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,4 @@
+project('i3c-tools', 'c')
+
+executable('i3ctransfer', 'i3ctransfer.c', install: true, 
+	include_directories: include_directories('include'))


### PR DESCRIPTION
i3c-tools is useful for testing i3c protocol, and we use meson
build system for OpenBMC project.

Any suggestion are welcome.

Signed-off-by: Troy Lee <troy_lee@aspeedtech.com>